### PR TITLE
patch 0.8.8.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: mda.streams
 Type: Package
 Title: Data Preparation, Access, and Analysis Functions for the Powell Center Continental Stream Metabolism Project
-Version: 0.8.8.3
-Date: 2015-11-25
+Version: 0.8.8.5
+Date: 2015-12-03
 Author: Alison Appling, Luke A Winslow, Jordan S Read
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Back end tools for powstreams.

--- a/R/config_to_metab.R
+++ b/R/config_to_metab.R
@@ -98,17 +98,15 @@ config_to_metab <- function(config, rows, verbose=TRUE, prep_only=FALSE) {
         attr(out, "warnings") <- attr(metab_data_list, "warnings")
         return(out)
       } else {
-        # if the data are valid, also remove units and rows with NAs. eventually 
-        # want to be able to pass units to metab_fun.
+        # if the data are valid, also remove units. eventually want to be able
+        # to pass units to metab_fun.
         . <- '.dplyr.var'
         metab_data <- metab_data_list$data
         metab_data <- u(metab_data, get_units(metab_data) %>% replace(., which(.=="mg L^-1"), "mgO2 L^-1"))
         metab_data <- v(metab_data)
-        metab_data <- metab_data[complete.cases(metab_data),]
         metab_data_daily <- metab_data_list$data_daily
         if(!is.null(metab_data_daily)) {
           metab_data_daily <- v(metab_data_daily)
-          metab_data_daily <- metab_data_daily[complete.cases(metab_data_daily),]
         }
       }
       

--- a/R/modernize_metab_model.R
+++ b/R/modernize_metab_model.R
@@ -25,8 +25,9 @@ modernize_metab_model <- function(metab_model) {
     # config. if the config isn't complete, add the needed columns as NAs.
     old_info <- get_info(old_mm)
     old_config <- if(is.data.frame(old_info)) old_info else old_info$config
-    empty_config <- suppressWarnings(stage_metab_config(tag='0.0.0', strategy='updating SB metab model', site=NA, filename=NULL))
-    new_config <- bind_rows(empty_config, old_config) %>% as.data.frame
+    if('config.row' %in% names(old_config)) old_config$config.row <- as.numeric(old_config$config.row)
+    empty_config <- stage_metab_config(tag='0.0.0', strategy='updating SB metab model', site=NA, filename=NULL)
+    new_config <- bind_rows(empty_config, old_config) %>% as.data.frame(stringsAsFactors=FALSE)
     if(!('config.row' %in% names(old_config))) {
       new_config$config.row <- rownames(old_config)
     }

--- a/R/stage_metab_config.R
+++ b/R/stage_metab_config.R
@@ -51,6 +51,10 @@
 #'   simulation. See Data Source Format below.
 #' @param K600 Data Source for reaeration rates for use in data simulation. See 
 #'   Data Source Format below.
+#' @param K600lwr Data Source for lower bound on reaeration rates for use in
+#'   data simulation. See Data Source Format below.
+#' @param K600upr Data Source for upper bound on reaeration rates for use in
+#'   data simulation. See Data Source Format below.
 #' @param dischdaily Data Source for daily mean stream discharge, for use in 
 #'   identifying daily priors or fixed values for K600. See Data Source Format 
 #'   below.

--- a/R/stage_metab_ts.R
+++ b/R/stage_metab_ts.R
@@ -19,7 +19,7 @@ stage_metab_ts <- function(metab_outs, folder = tempdir(), verbose = FALSE) {
   
   staged <- unname(unlist(lapply(metab_outs, function(metab_mod) {
     # pull info from the model
-    config_row <- get_info(metab_mod)
+    config_row <- get_info(metab_mod)$config
     mod_model <- config_row[[1,"model"]]
     src <- switch(
       mod_model,
@@ -33,7 +33,7 @@ stage_metab_ts <- function(metab_outs, folder = tempdir(), verbose = FALSE) {
     # represent each corresponding Date
     coords <- get_site_coords(site)
     preds$DateTime <- convert_solartime_to_GMT(
-      as.POSIXct(paste0(preds$date, " 12:00:00"), tz="UTC"), 
+      as.POSIXct(paste0(preds$local.date, " 12:00:00"), tz="UTC"), 
       longitude=coords$lon, time.type="mean solar")
     
     # extract specific columns into ts files. this section will need rewriting

--- a/R/summarize_metab_model.R
+++ b/R/summarize_metab_model.R
@@ -40,6 +40,7 @@ summarize_metab_model <- function(
   }
   
   # parse the name into some starter information about each model
+  tag <- '.dplyr.var'
   model_info <- parse_metab_model_name(model_name) %>% 
     add_rownames(var="model_name") %>% 
     mutate(tag=as.character(tag)) %>%

--- a/man/stage_metab_config.Rd
+++ b/man/stage_metab_config.Rd
@@ -80,6 +80,12 @@ simulation. See Data Source Format below.}
 \item{K600}{Data Source for reaeration rates for use in data simulation. See
 Data Source Format below.}
 
+\item{K600lwr}{Data Source for lower bound on reaeration rates for use in
+data simulation. See Data Source Format below.}
+
+\item{K600upr}{Data Source for upper bound on reaeration rates for use in
+data simulation. See Data Source Format below.}
+
 \item{dischdaily}{Data Source for daily mean stream discharge, for use in
 identifying daily priors or fixed values for K600. See Data Source Format
 below.}


### PR DESCRIPTION
* accommodate Kmodel days without complete daily inputs (in config_to_metab)
* fix modernize_metab_model to convert config_row to numeric
* fix stage_metab_config to use new convention for storage location of config, colname of local.date
* add omitted .dplyr.vars, param definitions in doc (r cmd check fixes)