### PR TITLE
bugfix for mfootdaily ts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Package: mda.streams
 Type: Package
 Title: Data Preparation, Access, and Analysis Functions for the Powell Center
     Continental Stream Metabolism Project
-Version: 0.10.1
-Date: 2017-08-20
+Version: 0.10.2
+Date: 2017-08-21
 Author: Alison P Appling, Luke A Winslow, Jordan S Read, Lindsay Carr
 Maintainer: Alison Appling <aappling@usgs.gov>
 Description: Back end tools for powstreams.

--- a/R/get_ts.R
+++ b/R/get_ts.R
@@ -97,10 +97,13 @@ get_ts <- function(var_src, site_name, method=c('approx', 'full_join', 'left_joi
     to_condense <- grep("Condensed", warning_info$result)
     
     . <- '.dplyr.var'
-    longitude <- ifelse(length(to_condense) != 0, 
-                        get_meta("basic") %>% v() %>% filter(site_name == get('site_name')) %>% .$lon,
-                        NA)
-    
+    longitude <- if(length(to_condense) != 0) {
+      mb <- v(get_meta('basic'))
+      mb[mb$site_name == site_name, 'lon']
+    } else {
+      NA
+    }
+
     #distinguish NA observations from NAs added during the full_join
     if(length(to_condense) > 0) {
       original_obs_list <- lapply(data_list_ordered[to_condense], function(d){

--- a/R/stage_calc_ts.R
+++ b/R/stage_calc_ts.R
@@ -349,8 +349,7 @@ stage_calc_ts <- function(sites, var, src, folder = tempdir(), version=c('rds','
           'mfootdaily_calc3vK' = {
             combo_daily <- get_staging_ts(
               var_src=c('sitedate_calcLon', 'K600_estBest', choose_ts('veloc'), choose_ts('wtr')), 
-              condense_stat = mean, day_start=day_start, day_end=day_end,
-              method='approx')
+              match_var='K600_estBest', condense_stat = mean, day_start=day_start, day_end=day_end)
             calc_mfootdaily_calc3vK(
               utctime=combo_daily$DateTime,
               K600=combo_daily$K600,


### PR DESCRIPTION
an `ifelse` was assigning every site the same longitude as the first site in the metadata table, which was throwing off the daily timestamps (the UTC time for local mean solar noon was wrong), which was causing daily values (e.g., K600) to merge poorly with daily means of instantaneous values (e.g., wtr). this fix means all the calculated tses for `mfootdaily` on SB need to be redone (doing that now).